### PR TITLE
Add GitHub Action with automatic tag creation on push to main

### DIFF
--- a/.github/workflows/create_tag.yml
+++ b/.github/workflows/create_tag.yml
@@ -1,0 +1,58 @@
+name: Create tag on version change
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - pyproject.toml
+      - .github/workflows/create_tag.yml
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Create virtual environment
+        run: |
+          uv venv
+
+      - name: Get version from pyproject.toml
+        id: get-version
+        run: |
+          uv add tomli
+          VERSION=$(uv run python -c "import tomli; print(tomli.loads(open('pyproject.toml', 'r').read())['project']['version'])")
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "🟢 Version extracted from pyproject.toml: $VERSION"
+
+      - name: Check if tag with version from pyproject.toml already exists
+        id: check-tag
+        run: |
+          git fetch --tags
+          TAG_EXISTS=$(git tag --list "v${{ steps.get-version.outputs.VERSION }}")
+          if [ -n "$TAG_EXISTS" ]; then
+            echo "⚫ Tag v${{ steps.get-version.outputs.VERSION }} already exists. Skipping tag creation."
+            echo "SKIP_CREATING_TAG=true" >> $GITHUB_ENV
+          else
+            echo "🟢 Tag v${{ steps.get-version.outputs.VERSION }} does not exist. Proceeding with tag creation."
+            echo "SKIP_CREATING_TAG=false" >> $GITHUB_ENV
+          fi
+
+      - name: Create tag with version from pyproject.toml
+        if: env.SKIP_CREATING_TAG == 'false'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+          git tag -a "v${{ steps.get-version.outputs.VERSION }}" -m "v${{ steps.get-version.outputs.VERSION }}"
+          git push origin "v${{ steps.get-version.outputs.VERSION }}"
+          echo "🟢 Tag v${{ steps.get-version.outputs.VERSION }} created and pushed to origin."


### PR DESCRIPTION
Hello @FrancescoSaverioZuppichini! 👋 

I noticed in `README.md` that GitHub Action described as "auto creating a new tag on push on main, sync versions" is still on the to do list. Due to the fact that I've been playing with GitHub Actions lately, I decided to implement it.
I hope I understood correctly your idea of this workflow.

### PR Description

This PR introduces a new GitHub Actions workflow, `create_tag.yml`, to automate the creation of tags whenever the version in `pyproject.toml` changes. Here's a quick breakdown of the workflow logic:

#### GitHub Action trigger 
It runs on every push to the `main` branch (specifically when `pyproject.toml` was modified).

#### GitHub Action key steps
1. Extract version from pyproject.toml
2. Check if the tag with this version already exists
3. Create and push the tag (if it doesn't exist)

### How has it been tested?

I tested it on the fork of this repository:
- [GitHub Action when tag was created](https://github.com/mpfmorawski/python-template/actions/runs/14393422843/job/40364799022) -> [Release v0.1.3 tag](https://github.com/mpfmorawski/python-template/releases/tag/v0.1.3)
- [GitHub Action when tag was not created because tag related to this version already exists](https://github.com/mpfmorawski/python-template/actions/runs/14393649791/job/40365398212)